### PR TITLE
Disable node editing in review mode

### DIFF
--- a/session.h
+++ b/session.h
@@ -38,23 +38,24 @@ enum class GUIMode {
 };
 
 enum class AnnotationMode {
-    NodeEditing = 1 << 0,
-    LinkedNodes = 1 << 1,
-    SkeletonCycles = 1 << 2,
-    Brush = 1 << 3,
-    ObjectSelection = 1 << 4,
-    ObjectMerge = 1 << 5,
+    NodeSelection = 1 << 0,
+    NodeEditing = 1 << 1 | NodeSelection,
+    LinkedNodes = 1 << 2,
+    SkeletonCycles = 1 << 3,
+    Brush = 1 << 4,
+    ObjectSelection = 1 << 5,
+    ObjectMerge = 1 << 6,
 
-    Mode_Tracing = (1 << 6) | NodeEditing,
-    Mode_TracingAdvanced = (1 << 7) | NodeEditing | SkeletonCycles,
+    Mode_Tracing = (1 << 7) | NodeEditing,
+    Mode_TracingAdvanced = (1 << 8) | NodeEditing | SkeletonCycles,
 
-    Mode_Paint = (1 << 8) | Brush | ObjectSelection,
-    Mode_Merge = (1 << 9) | Brush | ObjectSelection | ObjectMerge,
-    Mode_MergeSimple = (1 << 10) | Brush | ObjectMerge,
+    Mode_Paint = (1 << 9) | Brush | ObjectSelection,
+    Mode_Merge = (1 << 10) | Brush | ObjectSelection | ObjectMerge,
+    Mode_MergeSimple = (1 << 11) | Brush | ObjectMerge,
 
-    Mode_MergeTracing = (1 << 11) | NodeEditing | LinkedNodes | SkeletonCycles,
+    Mode_MergeTracing = (1 << 12) | NodeEditing | LinkedNodes | SkeletonCycles,
 
-    Mode_Selection = (1 << 12) | ObjectSelection,
+    Mode_Selection = (1 << 13) | NodeSelection | ObjectSelection,
 };
 
 class Session : public QObject {

--- a/session.h
+++ b/session.h
@@ -54,7 +54,7 @@ enum class AnnotationMode {
 
     Mode_MergeTracing = (1 << 11) | NodeEditing | LinkedNodes | SkeletonCycles,
 
-    Mode_Selection = (1 << 12) | Mode_TracingAdvanced | ObjectSelection,
+    Mode_Selection = (1 << 12) | ObjectSelection,
 };
 
 class Session : public QObject {

--- a/widgets/tools/skeletonview.cpp
+++ b/widgets/tools/skeletonview.cpp
@@ -642,9 +642,9 @@ SkeletonView::SkeletonView(QWidget * const parent) : QWidget{parent}
         treeContextMenu.actions().at(deleteActionIndex = i++)->setEnabled(nodeEditing && selectedTrees.size() > 0);//delete
         //display the context menu at pos in screen coordinates instead of widget coordinates of the content of the currently focused table
         treeContextMenu.exec(treeView.viewport()->mapToGlobal(pos));
-        // make some actions always available when ctx menu isn’t shown
+        // make shortcuted actions always available for when ctx menu isn’t shown
         treeContextMenu.actions().at(copyActionIndex)->setEnabled(true);
-        treeContextMenu.actions().at(deleteActionIndex)->setEnabled(nodeEditing);
+        treeContextMenu.actions().at(deleteActionIndex)->setEnabled(true);
     });
     nodeView.setContextMenuPolicy(Qt::CustomContextMenu);//enables signal for custom context menu
     QObject::connect(&nodeView, &QTreeView::customContextMenuRequested, [this](const QPoint & pos){
@@ -673,9 +673,9 @@ SkeletonView::SkeletonView(QWidget * const parent) : QWidget{parent}
         nodeContextMenu.actions().at(deleteActionIndex = i++)->setEnabled(nodeEditing && selectedNodes.size() > 0);//delete
         //display the context menu at pos in screen coordinates instead of widget coordinates of the content of the currently focused table
         nodeContextMenu.exec(nodeView.viewport()->mapToGlobal(pos));
-        // make some actions available when ctx menu isn’t shown
+        // make shortcuted actions always available for when ctx menu isn’t shown
         nodeContextMenu.actions().at(copyActionIndex)->setEnabled(true);
-        nodeContextMenu.actions().at(deleteActionIndex)->setEnabled(nodeEditing);
+        nodeContextMenu.actions().at(deleteActionIndex)->setEnabled(true);
     });
 
     QObject::connect(treeContextMenu.addAction("&Jump to first node"), &QAction::triggered, [](){
@@ -749,8 +749,8 @@ SkeletonView::SkeletonView(QWidget * const parent) : QWidget{parent}
             }
         });
     });
-    deleteAction(treeContextMenu, treeView, tr("&Delete trees"), [](){
-        if (!state->skeletonState->selectedTrees.empty()) {
+    deleteAction(treeContextMenu, treeView, tr("&Delete trees"), [](){// this is also a shortcut and needs checks here
+        if (Session::singleton().annotationMode.testFlag(AnnotationMode::NodeEditing) && !state->skeletonState->selectedTrees.empty()) {
             question([](){ Skeletonizer::singleton().deleteSelectedTrees(); }, tr("Delete"), tr("Delete selected trees?"));
         }
     });
@@ -872,8 +872,8 @@ SkeletonView::SkeletonView(QWidget * const parent) : QWidget{parent}
             prevRadius = radius;// save for the next time the dialog is opened
         }
     });
-    deleteAction(nodeContextMenu, nodeView, tr("&Delete nodes"), [](){
-        if (!state->skeletonState->selectedNodes.empty()) {
+    deleteAction(nodeContextMenu, nodeView, tr("&Delete nodes"), [](){// this is also a shortcut and needs checks here
+        if (Session::singleton().annotationMode.testFlag(AnnotationMode::NodeEditing) && !state->skeletonState->selectedNodes.empty()) {
             if (state->skeletonState->selectedNodes.size() == 1) {//don’t ask for one node
                 Skeletonizer::singleton().deleteSelectedNodes();
             } else {

--- a/widgets/viewports/viewportevents.cpp
+++ b/widgets/viewports/viewportevents.cpp
@@ -139,7 +139,7 @@ void ViewportBase::handleLinkToggle(const QMouseEvent & event) {
 }
 
 void ViewportBase::handleMouseButtonLeft(const QMouseEvent *event) {
-    if (Session::singleton().annotationMode.testFlag(AnnotationMode::NodeEditing)) {
+    if (Session::singleton().annotationMode.testFlag(AnnotationMode::NodeEditing) || Session::singleton().annotationMode.testFlag(AnnotationMode::Mode_Selection)) {
         const bool selection = event->modifiers().testFlag(Qt::ShiftModifier) || event->modifiers().testFlag(Qt::ControlModifier);
         if (selection) {
             startNodeSelection(event->pos().x(), event->pos().y(), viewportType, event->modifiers());
@@ -174,7 +174,9 @@ void ViewportOrtho::handleMouseButtonRight(const QMouseEvent *event) {
         segmentation_brush_work(event, *this);
         return;
     }
-
+    if (!annotationMode.testFlag(AnnotationMode::NodeEditing)) {
+        return;
+    }
     Coordinate clickedCoordinate = getCoordinateFromOrthogonalClick(event->pos(), *this);
     if (Session::singleton().outsideMovementArea(clickedCoordinate)) {
         return;
@@ -355,7 +357,7 @@ void ViewportBase::handleMouseReleaseLeft(const QMouseEvent *event) {
         }
     }
 
-    if (Session::singleton().annotationMode.testFlag(AnnotationMode::NodeEditing)) {
+    if (Session::singleton().annotationMode.testFlag(AnnotationMode::NodeEditing) || Session::singleton().annotationMode.testFlag(AnnotationMode::Mode_Selection)) {
         QSet<nodeListElement*> selectedNodes;
         int diffX = std::abs(state->viewerState->nodeSelectionSquare.first.x - event->pos().x());
         int diffY = std::abs(state->viewerState->nodeSelectionSquare.first.y - event->pos().y());
@@ -570,7 +572,7 @@ void ViewportBase::handleKeyPress(const QKeyEvent *event) {
             if (state->skeletonState->activeTree != nullptr) {
                 Skeletonizer::singleton().delTree(state->skeletonState->activeTree->treeID);
             }
-        } else if (!state->skeletonState->selectedNodes.empty()) {
+        } else if (Session::singleton().annotationMode.testFlag(AnnotationMode::NodeEditing) && !state->skeletonState->selectedNodes.empty()) {
             bool deleteNodes = true;
             if (state->skeletonState->selectedNodes.size() > 1) {
                 QMessageBox prompt{QApplication::activeWindow()};

--- a/widgets/viewports/viewportevents.cpp
+++ b/widgets/viewports/viewportevents.cpp
@@ -139,7 +139,7 @@ void ViewportBase::handleLinkToggle(const QMouseEvent & event) {
 }
 
 void ViewportBase::handleMouseButtonLeft(const QMouseEvent *event) {
-    if (Session::singleton().annotationMode.testFlag(AnnotationMode::NodeEditing) || Session::singleton().annotationMode.testFlag(AnnotationMode::Mode_Selection)) {
+    if (Session::singleton().annotationMode.testFlag(AnnotationMode::NodeSelection)) {
         const bool selection = event->modifiers().testFlag(Qt::ShiftModifier) || event->modifiers().testFlag(Qt::ControlModifier);
         if (selection) {
             startNodeSelection(event->pos().x(), event->pos().y(), viewportType, event->modifiers());
@@ -357,7 +357,7 @@ void ViewportBase::handleMouseReleaseLeft(const QMouseEvent *event) {
         }
     }
 
-    if (Session::singleton().annotationMode.testFlag(AnnotationMode::NodeEditing) || Session::singleton().annotationMode.testFlag(AnnotationMode::Mode_Selection)) {
+    if (Session::singleton().annotationMode.testFlag(AnnotationMode::NodeSelection)) {
         QSet<nodeListElement*> selectedNodes;
         int diffX = std::abs(state->viewerState->nodeSelectionSquare.first.x - event->pos().x());
         int diffY = std::abs(state->viewerState->nodeSelectionSquare.first.y - event->pos().y());


### PR DESCRIPTION
Can select nodes or change active node.

Tree edits still possible, e.g. merging, moving nodes between trees.