### PR TITLE
Applied most suggested changes proposed by clang-tidy

### DIFF
--- a/commentsetting.cpp
+++ b/commentsetting.cpp
@@ -27,8 +27,8 @@ bool CommentSetting::useCommentNodeRadius;
 bool CommentSetting::appendComment;
 std::vector<CommentSetting> CommentSetting::comments;
 
-QColor CommentSetting::getColor(const QString& comment) {
-    for(const auto& item : comments) {
+QColor CommentSetting::getColor(const QString & comment) {
+    for(const auto & item : comments) {
         if(!item.text.isEmpty() && comment.contains(item.text, Qt::CaseInsensitive)) {
             return item.color;
         }
@@ -36,8 +36,8 @@ QColor CommentSetting::getColor(const QString& comment) {
     return Qt::yellow;
 }
 
-float CommentSetting::getRadius(const QString& comment) {
-    for(const auto& item : comments) {
+float CommentSetting::getRadius(const QString & comment) {
+    for(const auto & item : comments) {
         if(!item.text.isEmpty() && comment.contains(item.text, Qt::CaseInsensitive)) {
             return item.nodeRadius;
         }

--- a/commentsetting.cpp
+++ b/commentsetting.cpp
@@ -27,11 +27,8 @@ bool CommentSetting::useCommentNodeRadius;
 bool CommentSetting::appendComment;
 std::vector<CommentSetting> CommentSetting::comments;
 
-CommentSetting::CommentSetting(const QString shortcut, const QString text, const QColor color, const float nodeRadius) :
-    shortcut(shortcut), text(text), color(color), nodeRadius(nodeRadius) { }
-
-QColor CommentSetting::getColor(const QString comment) {
-    for(const auto item : comments) {
+QColor CommentSetting::getColor(const QString& comment) {
+    for(const auto& item : comments) {
         if(!item.text.isEmpty() && comment.contains(item.text, Qt::CaseInsensitive)) {
             return item.color;
         }
@@ -39,8 +36,8 @@ QColor CommentSetting::getColor(const QString comment) {
     return Qt::yellow;
 }
 
-float CommentSetting::getRadius(const QString comment) {
-    for(const auto item : comments) {
+float CommentSetting::getRadius(const QString& comment) {
+    for(const auto& item : comments) {
         if(!item.text.isEmpty() && comment.contains(item.text, Qt::CaseInsensitive)) {
             return item.nodeRadius;
         }

--- a/commentsetting.h
+++ b/commentsetting.h
@@ -43,7 +43,7 @@ public:
     static std::vector<CommentSetting> comments;
 
     explicit CommentSetting(QString shortcut, QString text = "", QColor color = QColor(255, 255, 0, 255), const float nodeRadius = 1.5) :
-        shortcut(std::move(shortcut)), text(std::move(text)), color(std::move(color)), nodeRadius(nodeRadius) {}
+        shortcut(shortcut), text(text), color(color), nodeRadius(nodeRadius) {}
 
     static QColor getColor(const QString & comment);
     static float getRadius(const QString & comment);

--- a/commentsetting.h
+++ b/commentsetting.h
@@ -42,7 +42,7 @@ public:
     static bool appendComment;
     static std::vector<CommentSetting> comments;
 
-    explicit CommentSetting(QString  shortcut, QString  text = "", QColor  color = QColor(255, 255, 0, 255), const float nodeRadius = 1.5) :
+    explicit CommentSetting(QString shortcut, QString text = "", QColor color = QColor(255, 255, 0, 255), const float nodeRadius = 1.5) :
         shortcut(std::move(shortcut)), text(std::move(text)), color(std::move(color)), nodeRadius(nodeRadius) {}
 
     static QColor getColor(const QString & comment);

--- a/commentsetting.h
+++ b/commentsetting.h
@@ -45,8 +45,8 @@ public:
     explicit CommentSetting(QString  shortcut, QString  text = "", QColor  color = QColor(255, 255, 0, 255), const float nodeRadius = 1.5) :
         shortcut(std::move(shortcut)), text(std::move(text)), color(std::move(color)), nodeRadius(nodeRadius) {}
 
-    static QColor getColor(const QString& comment);
-    static float getRadius(const QString& comment);
+    static QColor getColor(const QString & comment);
+    static float getRadius(const QString & comment);
 };
 
 #endif // COMMENTSETTING_H

--- a/commentsetting.h
+++ b/commentsetting.h
@@ -25,6 +25,7 @@
 
 #include <QColor>
 
+#include <utility>
 #include <vector>
 
 class CommentSetting {
@@ -41,10 +42,11 @@ public:
     static bool appendComment;
     static std::vector<CommentSetting> comments;
 
-    explicit CommentSetting(const QString shortcut, const QString text = "", const QColor color = QColor(255, 255, 0, 255), const float nodeRadius = 1.5);
+    explicit CommentSetting(QString  shortcut, QString  text = "", QColor  color = QColor(255, 255, 0, 255), const float nodeRadius = 1.5) :
+        shortcut(std::move(shortcut)), text(std::move(text)), color(std::move(color)), nodeRadius(nodeRadius) {}
 
-    static QColor getColor(const QString comment);
-    static float getRadius(const QString comment);
+    static QColor getColor(const QString& comment);
+    static float getRadius(const QString& comment);
 };
 
 #endif // COMMENTSETTING_H

--- a/dataset.cpp
+++ b/dataset.cpp
@@ -144,7 +144,7 @@ Dataset::list_t Dataset::parsePyKnossosConf(const QUrl & configUrl, QString conf
     QString line;
     while (!(line = stream.readLine()).isNull()) {
         const QStringList tokenList = line.split(QRegularExpression("( = |,)"));
-        const QString token = tokenList.front();
+        const QString& token = tokenList.front();
         if (token.startsWith("[Dataset")) {
             infos.emplace_back();
             infos.back().api = API::PyKnossos;

--- a/dataset.cpp
+++ b/dataset.cpp
@@ -144,7 +144,7 @@ Dataset::list_t Dataset::parsePyKnossosConf(const QUrl & configUrl, QString conf
     QString line;
     while (!(line = stream.readLine()).isNull()) {
         const QStringList tokenList = line.split(QRegularExpression("( = |,)"));
-        const QString& token = tokenList.front();
+        const QString & token = tokenList.front();
         if (token.startsWith("[Dataset")) {
             infos.emplace_back();
             infos.back().api = API::PyKnossos;

--- a/functions.h
+++ b/functions.h
@@ -32,9 +32,9 @@ bool currentlyVisible(const Coordinate & coord, const Coordinate & center, const
 class Rotation {
 public:
     floatCoordinate axis;
-    float alpha;
+    float alpha{};
 
-    Rotation() : axis(floatCoordinate(0, 0 ,0)), alpha(0) {}
+    Rotation() : axis(floatCoordinate(0, 0 ,0))  {}
     Rotation(const floatCoordinate & axis, const float alpha) : axis(axis), alpha(alpha) {}
 };
 

--- a/functions.h
+++ b/functions.h
@@ -34,7 +34,7 @@ public:
     floatCoordinate axis;
     float alpha{};
 
-    Rotation() : axis(floatCoordinate(0, 0 ,0))  {}
+    Rotation() = default;
     Rotation(const floatCoordinate & axis, const float alpha) : axis(axis), alpha(alpha) {}
 };
 

--- a/loader.h
+++ b/loader.h
@@ -118,7 +118,7 @@ public://matsch
     void flushIntoSnappyCache();
     void broadcastProgress(bool startup = false);
     Worker(const decltype(datasets) &);
-    ~Worker() override;
+    virtual ~Worker() override;
 signals:
     void progress(bool incremented, int count);
 public slots:
@@ -138,7 +138,7 @@ public:
         return loader;
     }
     void suspendLoader();
-    ~Controller() override;
+    virtual ~Controller() override;
     void unloadCurrentMagnification();
 
     template<typename... Args>

--- a/remote.cpp
+++ b/remote.cpp
@@ -101,7 +101,7 @@ std::deque<floatCoordinate> Remote::getLastNodes() {
                 }
             }
         }
-        nodelist.push_back(node->position);
+        nodelist.emplace_back(node->position);
     }
 
     return nodelist;

--- a/scriptengine/decorators/coordinatedecorator.h
+++ b/scriptengine/decorators/coordinatedecorator.h
@@ -31,7 +31,7 @@ class CoordinateDecorator : public QObject
 {
     Q_OBJECT
 public:
-    explicit CoordinateDecorator(QObject *parent = 0);
+    explicit CoordinateDecorator(QObject *parent = nullptr);
 
 
 signals:

--- a/scriptengine/decorators/floatcoordinatedecorator.h
+++ b/scriptengine/decorators/floatcoordinatedecorator.h
@@ -31,7 +31,7 @@ class FloatCoordinateDecorator : public QObject
 {
     Q_OBJECT
 public:
-    explicit FloatCoordinateDecorator(QObject *parent = 0);    
+    explicit FloatCoordinateDecorator(QObject *parent = nullptr);
 
 signals:
 

--- a/scriptengine/decorators/nodelistdecorator.h
+++ b/scriptengine/decorators/nodelistdecorator.h
@@ -34,7 +34,7 @@ class NodeListDecorator : public QObject
     template<typename, std::size_t> friend class Coord;
     Q_OBJECT
 public:
-    explicit NodeListDecorator(QObject *parent = 0);
+    explicit NodeListDecorator(QObject *parent = nullptr);
 
 signals:
 

--- a/scriptengine/decorators/segmentlistdecorator.h
+++ b/scriptengine/decorators/segmentlistdecorator.h
@@ -31,7 +31,7 @@ class SegmentListDecorator : public QObject
 {
     Q_OBJECT
 public:
-    explicit SegmentListDecorator(QObject *parent = 0);
+    explicit SegmentListDecorator(QObject *parent = nullptr);
 
 signals:
 

--- a/scriptengine/decorators/treelistdecorator.h
+++ b/scriptengine/decorators/treelistdecorator.h
@@ -34,7 +34,7 @@ class treeListElement;
 class TreeListDecorator : public QObject {
     Q_OBJECT
 public:
-    explicit TreeListDecorator(QObject *parent = 0);
+    explicit TreeListDecorator(QObject *parent = nullptr);
 
 public slots:
     QColor color(treeListElement *self);

--- a/scriptengine/highlighter.h
+++ b/scriptengine/highlighter.h
@@ -43,7 +43,7 @@ public:
 signals:
 
 public slots:
-    void highlightBlock(const QString &text) override;
+    virtual void highlightBlock(const QString &text) override;
 
 
 };

--- a/scriptengine/highlighter.h
+++ b/scriptengine/highlighter.h
@@ -43,7 +43,7 @@ public:
 signals:
 
 public slots:
-    void highlightBlock(const QString &text);
+    void highlightBlock(const QString &text) override;
 
 
 };

--- a/scriptengine/proxies/pythonproxy.cpp
+++ b/scriptengine/proxies/pythonproxy.cpp
@@ -99,11 +99,11 @@ void PythonProxy::coord_cubes_mark_changed_proxy(QVector<int> cubeChangeSetList)
 }
 
 quint64 PythonProxy::read_overlay_voxel(QList<int> coord) {
-    return readVoxel(std::move(coord));
+    return readVoxel(coord);
 }
 
 bool PythonProxy::write_overlay_voxel(QList<int> coord, quint64 val) {
-    return writeVoxel(std::move(coord), val);
+    return writeVoxel(coord, val);
 }
 
 void PythonProxy::set_position(QList<int> coord) {
@@ -115,7 +115,7 @@ void PythonProxy::reset_movement_area() {
 }
 
 void PythonProxy::set_movement_area(QList<int> minCoord, QList<int> maxCoord) {
-    Session::singleton().updateMovementArea(std::move(minCoord),std::move(maxCoord));
+    Session::singleton().updateMovementArea(minCoord,maxCoord);
 }
 
 QList<int> PythonProxy::get_movement_area() {
@@ -131,7 +131,7 @@ void PythonProxy::set_work_mode(const int mode) {
 }
 
 void PythonProxy::oc_reslice_notify_all(QList<int> coord) {
-    state->viewer->reslice_notify_all(Segmentation::singleton().layerId, Coordinate(std::move(coord)));
+    state->viewer->reslice_notify_all(Segmentation::singleton().layerId, Coordinate(coord));
 }
 
 int PythonProxy::loader_loading_nr() {

--- a/scriptengine/proxies/pythonproxy.cpp
+++ b/scriptengine/proxies/pythonproxy.cpp
@@ -99,11 +99,11 @@ void PythonProxy::coord_cubes_mark_changed_proxy(QVector<int> cubeChangeSetList)
 }
 
 quint64 PythonProxy::read_overlay_voxel(QList<int> coord) {
-    return readVoxel(coord);
+    return readVoxel(std::move(coord));
 }
 
 bool PythonProxy::write_overlay_voxel(QList<int> coord, quint64 val) {
-    return writeVoxel(coord, val);
+    return writeVoxel(std::move(coord), val);
 }
 
 void PythonProxy::set_position(QList<int> coord) {
@@ -115,7 +115,7 @@ void PythonProxy::reset_movement_area() {
 }
 
 void PythonProxy::set_movement_area(QList<int> minCoord, QList<int> maxCoord) {
-    Session::singleton().updateMovementArea(minCoord,maxCoord);
+    Session::singleton().updateMovementArea(std::move(minCoord),std::move(maxCoord));
 }
 
 QList<int> PythonProxy::get_movement_area() {
@@ -131,7 +131,7 @@ void PythonProxy::set_work_mode(const int mode) {
 }
 
 void PythonProxy::oc_reslice_notify_all(QList<int> coord) {
-    state->viewer->reslice_notify_all(Segmentation::singleton().layerId, Coordinate(coord));
+    state->viewer->reslice_notify_all(Segmentation::singleton().layerId, Coordinate(std::move(coord)));
 }
 
 int PythonProxy::loader_loading_nr() {

--- a/scriptengine/proxies/skeletonproxy.cpp
+++ b/scriptengine/proxies/skeletonproxy.cpp
@@ -244,7 +244,7 @@ bool SkeletonProxy::delete_segment(quint64 source_id, quint64 target_id) {
 }
 
 bool SkeletonProxy::delete_node(quint64 node_id) {
-    if (!Skeletonizer::singleton().delNode(node_id, NULL)) {
+    if (!Skeletonizer::singleton().delNode(node_id, nullptr)) {
         emit echo(QString("could not delete the node with id %1").arg(node_id));
         return false;
     }

--- a/scriptengine/scripting.h
+++ b/scriptengine/scripting.h
@@ -66,7 +66,7 @@ public:
     EmitOnCtorDtor(SignalType signalName, Class instance, Args && ...args) {
         emit std::mem_fn(signalName)(instance, this, std::forward<Args>(args)...);
     }
-    ~EmitOnCtorDtor() override {
+    virtual ~EmitOnCtorDtor() override {
         emit dtorSignal(dtorCtx);
     }
 public slots:

--- a/scriptengine/scripting.h
+++ b/scriptengine/scripting.h
@@ -34,6 +34,7 @@
 #include <QObject>
 
 #include <functional>
+#include <utility>
 
 /*
  * This class emits on ctor a signal of arbitrary parameters that is passed to the ctor,
@@ -65,11 +66,11 @@ public:
     EmitOnCtorDtor(SignalType signalName, Class instance, Args && ...args) {
         emit std::mem_fn(signalName)(instance, this, std::forward<Args>(args)...);
     }
-    ~EmitOnCtorDtor() {
+    ~EmitOnCtorDtor() override {
         emit dtorSignal(dtorCtx);
     }
 public slots:
-    void dtorSetCtx(QVariant ctx) { dtorCtx = ctx;}
+    void dtorSetCtx(QVariant ctx) { dtorCtx = std::move(ctx);}
 signals:
     void dtorSignal(QVariant);
 private:

--- a/scriptengine/scripting.h
+++ b/scriptengine/scripting.h
@@ -70,7 +70,7 @@ public:
         emit dtorSignal(dtorCtx);
     }
 public slots:
-    void dtorSetCtx(QVariant ctx) { dtorCtx = std::move(ctx);}
+    void dtorSetCtx(QVariant ctx) { dtorCtx = ctx;}
 signals:
     void dtorSignal(QVariant);
 private:

--- a/segmentation/segmentation.cpp
+++ b/segmentation/segmentation.cpp
@@ -594,8 +594,8 @@ void Segmentation::mergelistLoad(QTextStream & stream) {
             std::istringstream coordColorLineStream(stream.readLine().toStdString());
 
             uint64_t objId;
-            bool todo = false;
-            bool immutable = false;
+            bool todo;
+            bool immutable;
             Coordinate location;
             uint r; uint g; uint b;
             uint64_t initialVolume;

--- a/segmentation/segmentation.cpp
+++ b/segmentation/segmentation.cpp
@@ -598,7 +598,7 @@ void Segmentation::mergelistLoad(QTextStream & stream) {
             bool immutable = false;
             Coordinate location;
             uint r; uint g; uint b;
-            uint64_t initialVolume = 0;
+            uint64_t initialVolume;
             QString category;
             QString comment;
 

--- a/segmentation/segmentation.cpp
+++ b/segmentation/segmentation.cpp
@@ -467,7 +467,7 @@ std::vector<std::reference_wrapper<Segmentation::Object>> Segmentation::todolist
     std::vector<std::reference_wrapper<Segmentation::Object>> todolist;
     for (auto & obj : objects) {
         if(obj.todo) {
-            todolist.push_back(obj);
+            todolist.emplace_back(obj);
         }
     }
     std::sort(todolist.begin(), todolist.end());
@@ -594,11 +594,11 @@ void Segmentation::mergelistLoad(QTextStream & stream) {
             std::istringstream coordColorLineStream(stream.readLine().toStdString());
 
             uint64_t objId;
-            bool todo;
-            bool immutable;
+            bool todo = false;
+            bool immutable = false;
             Coordinate location;
             uint r; uint g; uint b;
-            uint64_t initialVolume;
+            uint64_t initialVolume = 0;
             QString category;
             QString comment;
 

--- a/session.cpp
+++ b/session.cpp
@@ -33,7 +33,7 @@ class Session::ActivityEventFilter : public QObject {
     bool & timeSliceActivity;
 public:
     ActivityEventFilter(Session & session) : QObject(&session), timeSliceActivity(session.timeSliceActivity) {}
-    bool eventFilter(QObject *object, QEvent *event) override {
+    virtual bool eventFilter(QObject *object, QEvent *event) override {
         // mark time slice as valid on any user actions except just moving the mouse
         int type = event->type();
         if (type == QEvent::MouseButtonPress || type == QEvent::KeyPress || type == QEvent::Wheel) {

--- a/session.cpp
+++ b/session.cpp
@@ -33,7 +33,7 @@ class Session::ActivityEventFilter : public QObject {
     bool & timeSliceActivity;
 public:
     ActivityEventFilter(Session & session) : QObject(&session), timeSliceActivity(session.timeSliceActivity) {}
-    bool eventFilter(QObject *object, QEvent *event) {
+    bool eventFilter(QObject *object, QEvent *event) override {
         // mark time slice as valid on any user actions except just moving the mouse
         int type = event->type();
         if (type == QEvent::MouseButtonPress || type == QEvent::KeyPress || type == QEvent::Wheel) {

--- a/skeleton/skeleton_dfs.h
+++ b/skeleton/skeleton_dfs.h
@@ -35,7 +35,7 @@ struct NodeGenerator {
     std::unordered_set<const nodeListElement *> queuedNodes;
     Direction direction{Direction::Any};
     bool reachedEnd{true};
-    NodeGenerator() {}
+    NodeGenerator() = default;
     NodeGenerator(nodeListElement & node, const Direction direction);
     bool operator!=(NodeGenerator & other);
     NodeGenerator & operator++();
@@ -47,7 +47,7 @@ struct TreeTraverser {
     NodeGenerator nodeIter;
     std::list<treeListElement> * trees;
     std::unordered_map<decltype(nodeListElement::nodeID), nodeListElement *>::iterator progress;
-    TreeTraverser() {}
+    TreeTraverser() = default;
     TreeTraverser(std::list<treeListElement> & trees, nodeListElement * node = nullptr);
     bool operator!=(TreeTraverser & other);
     TreeTraverser & operator++();

--- a/skeleton/skeletonizer.cpp
+++ b/skeleton/skeletonizer.cpp
@@ -50,6 +50,7 @@
 #include <queue>
 #include <type_traits>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 SkeletonState::SkeletonState() : skeletonCreatedInVersion{KREVISION} {}
@@ -1776,7 +1777,7 @@ void Skeletonizer::toggleNodeSelection(const QSet<nodeListElement*> & nodeSet) {
 }
 
 void Skeletonizer::selectNodes(QSet<nodeListElement*> nodeSet) {
-    select(nodeSet);
+    select(std::move(nodeSet));
 }
 
 void Skeletonizer::selectTrees(const std::vector<treeListElement*> & trees) {
@@ -1898,8 +1899,8 @@ void Skeletonizer::saveMesh(QIODevice & file, const treeListElement & tree) {
 void Skeletonizer::addMeshToTree(boost::optional<decltype(treeListElement::treeID)> treeID, QVector<float> & verts, QVector<float> & normals, QVector<unsigned int> & indices, QVector<std::uint8_t> & colors, int draw_mode, bool swap_xy) {
     std::vector<int> vertex_face_count(verts.size() / 3);
     try {
-        for(int i = 0; i < indices.size(); ++i) {
-            ++vertex_face_count.at(indices[i]); // use at() to be able to throw out_of_range exception
+        for(unsigned int indice : indices) {
+            ++vertex_face_count.at(indice);
         }
     } catch (const std::out_of_range & ex) {
         throw std::runtime_error(tr("Ply file contains triangle index greater than number of vertices: %1").arg(ex.what()).toStdString());

--- a/skeleton/skeletonizer.cpp
+++ b/skeleton/skeletonizer.cpp
@@ -1777,7 +1777,7 @@ void Skeletonizer::toggleNodeSelection(const QSet<nodeListElement*> & nodeSet) {
 }
 
 void Skeletonizer::selectNodes(QSet<nodeListElement*> nodeSet) {
-    select(std::move(nodeSet));
+    select(nodeSet);
 }
 
 void Skeletonizer::selectTrees(const std::vector<treeListElement*> & trees) {

--- a/skeleton/skeletonizer.cpp
+++ b/skeleton/skeletonizer.cpp
@@ -1900,7 +1900,7 @@ void Skeletonizer::addMeshToTree(boost::optional<decltype(treeListElement::treeI
     std::vector<int> vertex_face_count(verts.size() / 3);
     try {
         for(unsigned int indice : indices) {
-            ++vertex_face_count.at(indice);
+            ++vertex_face_count.at(indice); // use at() to be able to throw out_of_range exception
         }
     } catch (const std::out_of_range & ex) {
         throw std::runtime_error(tr("Ply file contains triangle index greater than number of vertices: %1").arg(ex.what()).toStdString());

--- a/skeleton/skeletonizer.cpp
+++ b/skeleton/skeletonizer.cpp
@@ -1899,7 +1899,7 @@ void Skeletonizer::saveMesh(QIODevice & file, const treeListElement & tree) {
 void Skeletonizer::addMeshToTree(boost::optional<decltype(treeListElement::treeID)> treeID, QVector<float> & verts, QVector<float> & normals, QVector<unsigned int> & indices, QVector<std::uint8_t> & colors, int draw_mode, bool swap_xy) {
     std::vector<int> vertex_face_count(verts.size() / 3);
     try {
-        for(unsigned int indice : indices) {
+        for(const auto indice : indices) {
             ++vertex_face_count.at(indice); // use at() to be able to throw out_of_range exception
         }
     } catch (const std::out_of_range & ex) {

--- a/slicer/gpucuber.h
+++ b/slicer/gpucuber.h
@@ -53,7 +53,7 @@ public:
     QOpenGLTexture cube{QOpenGLTexture::Target3D};
     std::vector<floatCoordinate> vertices;
     gpu_raw_cube(const int gpucubeedge, const bool index = false);
-    virtual ~gpu_raw_cube() {}
+    virtual ~gpu_raw_cube() = default;
     std::vector<char> prepare(boost::multi_array_ref<std::uint8_t, 3>::const_array_view<3>::type view);
     void upload(const std::vector<char> & data);
     void generate(boost::multi_array_ref<std::uint8_t, 3>::const_array_view<3>::type view);

--- a/viewer.cpp
+++ b/viewer.cpp
@@ -334,7 +334,7 @@ void Viewer::dcSliceExtract(std::uint8_t * datacube, floatCoordinate *currentPxI
 
         const int sliceIndex = 4 * ( s + *t  *  cubeEdgeLen * state->M);
         const int dcIndex = currentPxInDc.x + currentPxInDc.y * cubeEdgeLen + currentPxInDc.z * state->cubeSliceArea;
-        if(datacube == NULL) {
+        if(datacube == nullptr) {
             slice[sliceIndex] = slice[sliceIndex + 1] = slice[sliceIndex + 2] = 0;
         } else {
             if(useCustomLUT) {

--- a/viewer.cpp
+++ b/viewer.cpp
@@ -123,7 +123,7 @@ Viewer::Viewer() : evilHack{[this](){ state->viewer = this; return true; }()} {
             }
         }
     });
-    QObject::connect(&state->mainWindow->widgetContainer.datasetLoadWidget, &DatasetLoadWidget::datasetChanged, [this](){
+    QObject::connect(&state->mainWindow->widgetContainer.datasetLoadWidget, &DatasetLoadWidget::datasetChanged, [](){
         state->viewerState->regenVertBuffer = true;
     });
 

--- a/widgets/preferences/datasetsegmentationtab.h
+++ b/widgets/preferences/datasetsegmentationtab.h
@@ -73,7 +73,7 @@ class DatasetAndSegmentationTab : public QWidget
     void saveSettings() const;
     void loadSettings();
 public:
-    explicit DatasetAndSegmentationTab(QWidget *parent = 0);
+    explicit DatasetAndSegmentationTab(QWidget *parent = nullptr);
 
 signals:
     void volumeRenderToggled();

--- a/widgets/preferences/navigationtab.h
+++ b/widgets/preferences/navigationtab.h
@@ -89,7 +89,7 @@ class NavigationTab : public QWidget {
 
     void updateMovementArea();
 public:
-    explicit NavigationTab(QWidget *parent = 0);
+    explicit NavigationTab(QWidget *parent = nullptr);
     void loadSettings(const QSettings &settings);
     void saveSettings(QSettings &settings);
 };

--- a/widgets/preferences/nodestab.h
+++ b/widgets/preferences/nodestab.h
@@ -44,8 +44,8 @@ class PropertyModel : public QAbstractListModel {
     int numberPropertySize{0};
 public:
     PropertyModel();
-    int rowCount(const QModelIndex &) const override;
-    QVariant data(const QModelIndex & index, int role) const override;
+    virtual int rowCount(const QModelIndex &) const override;
+    virtual QVariant data(const QModelIndex & index, int role) const override;
     void recreate(const QSet<QString> & numberProperties, const QSet<QString> & textProperties);
 };
 

--- a/widgets/preferences/nodestab.h
+++ b/widgets/preferences/nodestab.h
@@ -44,8 +44,8 @@ class PropertyModel : public QAbstractListModel {
     int numberPropertySize{0};
 public:
     PropertyModel();
-    virtual int rowCount(const QModelIndex &) const override;
-    virtual QVariant data(const QModelIndex & index, int role) const override;
+    int rowCount(const QModelIndex &) const override;
+    QVariant data(const QModelIndex & index, int role) const override;
     void recreate(const QSet<QString> & numberProperties, const QSet<QString> & textProperties);
 };
 
@@ -80,7 +80,7 @@ class NodesTab : public QWidget {
     void saveSettings(QSettings &settings) const;
     void loadSettings(const QSettings &settings);
 public:
-    explicit NodesTab(QWidget *parent = 0);
+    explicit NodesTab(QWidget *parent = nullptr);
     void updateProperties(const QSet<QString> & properties, const QSet<QString> & textProperties);
 };
 

--- a/widgets/preferences/treestab.h
+++ b/widgets/preferences/treestab.h
@@ -47,13 +47,13 @@ public:
         setSpecialValueText("off");
         setRange(0, 64);
     }
-    virtual QValidator::State validate(QString &input, int &pos) const override {
+    QValidator::State validate(QString &input, int &pos) const override {
         const auto inRange = QSpinBox::validate(input, pos) == QValidator::Invalid;
         const auto number = static_cast<unsigned long>(valueFromText(input));
         const auto valid = inRange && (std::bitset<sizeof(number)>(number).count() <= 1);
         return inRange ? QValidator::Invalid : valid ? QValidator::Acceptable : QValidator::Intermediate;
     }
-    virtual void stepBy(int steps) override {
+    void stepBy(int steps) override {
         // we want 0 as value for 2^0 but have to calculate with 1
         const auto oldValue = value() == 0 ? 1 : value();
         const int newValue = std::pow(2, std::floor(std::log2(oldValue)) + steps);
@@ -93,7 +93,7 @@ class TreesTab : public QWidget
     void saveSettings(QSettings & settings) const;
     void loadSettings(const QSettings & settings);
 public:
-    explicit TreesTab(QWidget *parent = 0);
+    explicit TreesTab(QWidget *parent = nullptr);
 
 signals:
 

--- a/widgets/preferences/treestab.h
+++ b/widgets/preferences/treestab.h
@@ -47,13 +47,13 @@ public:
         setSpecialValueText("off");
         setRange(0, 64);
     }
-    QValidator::State validate(QString &input, int &pos) const override {
+    virtual QValidator::State validate(QString &input, int &pos) const override {
         const auto inRange = QSpinBox::validate(input, pos) == QValidator::Invalid;
         const auto number = static_cast<unsigned long>(valueFromText(input));
         const auto valid = inRange && (std::bitset<sizeof(number)>(number).count() <= 1);
         return inRange ? QValidator::Invalid : valid ? QValidator::Acceptable : QValidator::Intermediate;
     }
-    void stepBy(int steps) override {
+    virtual void stepBy(int steps) override {
         // we want 0 as value for 2^0 but have to calculate with 1
         const auto oldValue = value() == 0 ? 1 : value();
         const int newValue = std::pow(2, std::floor(std::log2(oldValue)) + steps);

--- a/widgets/preferences/viewporttab.h
+++ b/widgets/preferences/viewporttab.h
@@ -71,7 +71,7 @@ class ViewportTab : public QWidget {
     void saveSettings(QSettings & settings) const;
     void loadSettings(const QSettings & settings);
 public:
-    explicit ViewportTab(QWidget *parent = 0);
+    explicit ViewportTab(QWidget *parent = nullptr);
 };
 
 #endif // VIEWPORTTAB_H

--- a/widgets/task/taskmanagementwidget.cpp
+++ b/widgets/task/taskmanagementwidget.cpp
@@ -182,7 +182,7 @@ void TaskManagementWidget::logoutButtonClicked() {
     }
 }
 
-void TaskManagementWidget::saveAndLoadFile(const QString & filename, const QByteArray content) {
+void TaskManagementWidget::saveAndLoadFile(const QString & filename, const QByteArray & content) {
     QDir taskDir(QStandardPaths::writableLocation(QStandardPaths::DataLocation) + "/tasks");
     taskDir.mkpath("./task-files");//filenames of new tasks contain subfolder
 

--- a/widgets/task/taskmanagementwidget.h
+++ b/widgets/task/taskmanagementwidget.h
@@ -39,7 +39,7 @@ class TaskManagementWidget : public DialogVisibilityNotify {
     Q_OBJECT
     friend class TaskLoginWidget;
     const QString api{"/api/2"};
-    void saveAndLoadFile(const QString & filename, const QByteArray content);
+    void saveAndLoadFile(const QString & filename, const QByteArray & content);
 public:
     explicit TaskManagementWidget(QWidget *parent = nullptr);
 
@@ -69,7 +69,7 @@ protected:
     QPushButton logoutButton{"Logout"};
 
 public slots:
-    virtual void setVisible(bool enable) override;// showOrLoginOrHide
+    void setVisible(bool enable) override;// showOrLoginOrHide
 
     void updateAndRefreshWidget();
 

--- a/widgets/task/taskmanagementwidget.h
+++ b/widgets/task/taskmanagementwidget.h
@@ -69,7 +69,7 @@ protected:
     QPushButton logoutButton{"Logout"};
 
 public slots:
-    void setVisible(bool enable) override;// showOrLoginOrHide
+    virtual void setVisible(bool enable) override;// showOrLoginOrHide
 
     void updateAndRefreshWidget();
 

--- a/widgets/tools/commentstab.h
+++ b/widgets/tools/commentstab.h
@@ -40,12 +40,12 @@ protected:
 
 public:
     void fill();
-    virtual int rowCount(const QModelIndex & parent = QModelIndex()) const override;
-    virtual int columnCount(const QModelIndex & parent = QModelIndex()) const override;
-    virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
-    virtual QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const override;
-    virtual bool setData(const QModelIndex & index, const QVariant & value, int role = Qt::EditRole) override;
-    virtual Qt::ItemFlags flags(const QModelIndex & index) const override;
+    int rowCount(const QModelIndex & parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex & parent = QModelIndex()) const override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+    QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const override;
+    bool setData(const QModelIndex & index, const QVariant & value, int role = Qt::EditRole) override;
+    Qt::ItemFlags flags(const QModelIndex & index) const override;
 };
 
 
@@ -63,7 +63,7 @@ public:
     void saveSettings();
     void loadSettings();
     explicit CommentsTab(QWidget *parent = nullptr);
-    ~CommentsTab();
+    ~CommentsTab() override;
 
 signals:
 

--- a/widgets/tools/commentstab.h
+++ b/widgets/tools/commentstab.h
@@ -40,12 +40,12 @@ protected:
 
 public:
     void fill();
-    int rowCount(const QModelIndex & parent = QModelIndex()) const override;
-    int columnCount(const QModelIndex & parent = QModelIndex()) const override;
-    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
-    QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const override;
-    bool setData(const QModelIndex & index, const QVariant & value, int role = Qt::EditRole) override;
-    Qt::ItemFlags flags(const QModelIndex & index) const override;
+    virtual int rowCount(const QModelIndex & parent = QModelIndex()) const override;
+    virtual int columnCount(const QModelIndex & parent = QModelIndex()) const override;
+    virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+    virtual QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const override;
+    virtual bool setData(const QModelIndex & index, const QVariant & value, int role = Qt::EditRole) override;
+    virtual Qt::ItemFlags flags(const QModelIndex & index) const override;
 };
 
 

--- a/widgets/tools/commentstab.h
+++ b/widgets/tools/commentstab.h
@@ -63,7 +63,7 @@ public:
     void saveSettings();
     void loadSettings();
     explicit CommentsTab(QWidget *parent = nullptr);
-    ~CommentsTab() override;
+    virtual ~CommentsTab() override;
 
 signals:
 

--- a/widgets/tools/segmentationview.h
+++ b/widgets/tools/segmentationview.h
@@ -59,14 +59,14 @@ protected:
     const std::vector<QString> header{""/*color*/, "Object ID", "Lock", "Category", "Comment", "#", "Subobject IDs"};
     const std::size_t MAX_SHOWN_SUBOBJECTS = 10;
 public:
-    virtual int rowCount(const QModelIndex & parent = QModelIndex()) const override;
-    virtual int columnCount(const QModelIndex & parent = QModelIndex()) const override;
-    virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+    int rowCount(const QModelIndex & parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex & parent = QModelIndex()) const override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
     QVariant objectGet(const Segmentation::Object & obj, const QModelIndex & index, int role) const;
-    virtual QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const override;
+    QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const override;
     bool objectSet(Segmentation::Object & obj, const QModelIndex & index, const QVariant & value, int role);
-    virtual bool setData(const QModelIndex & index, const QVariant & value, int role = Qt::EditRole) override;
-    virtual Qt::ItemFlags flags(const QModelIndex & index) const override;
+    bool setData(const QModelIndex & index, const QVariant & value, int role = Qt::EditRole) override;
+    Qt::ItemFlags flags(const QModelIndex & index) const override;
     void recreate();
     void appendRowBegin();
     void popRowBegin();
@@ -79,9 +79,9 @@ class TouchedObjectModel : public SegmentationObjectModel {
     Q_OBJECT
 public:
     std::vector<std::reference_wrapper<Segmentation::Object>> objectCache;
-    virtual int rowCount(const QModelIndex & parent = QModelIndex()) const override;
-    virtual QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const override;
-    virtual bool setData(const QModelIndex & index, const QVariant & value, int role = Qt::EditRole) override;
+    int rowCount(const QModelIndex & parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const override;
+    bool setData(const QModelIndex & index, const QVariant & value, int role = Qt::EditRole) override;
     void recreate();
 };
 
@@ -89,8 +89,8 @@ class CategoryModel : public QAbstractListModel {
     Q_OBJECT
     std::vector<QString> categoriesCache;
 public:
-    virtual int rowCount(const QModelIndex &parent) const override;
-    virtual QVariant data(const QModelIndex &index, int role) const override;
+    int rowCount(const QModelIndex &parent) const override;
+    QVariant data(const QModelIndex &index, int role) const override;
     void recreate();
 };
 

--- a/widgets/tools/segmentationview.h
+++ b/widgets/tools/segmentationview.h
@@ -49,7 +49,7 @@ class CategoryDelegate : public QStyledItemDelegate {
     mutable PreventDeferredDelete<QComboBox> box;
 public:
     CategoryDelegate(class CategoryModel & categoryModel);
-    QWidget * createEditor(QWidget * parent, const QStyleOptionViewItem & option, const QModelIndex & index) const override;
+    virtual QWidget * createEditor(QWidget * parent, const QStyleOptionViewItem & option, const QModelIndex & index) const override;
 };
 
 class SegmentationObjectModel : public QAbstractListModel {

--- a/widgets/tools/segmentationview.h
+++ b/widgets/tools/segmentationview.h
@@ -59,14 +59,14 @@ protected:
     const std::vector<QString> header{""/*color*/, "Object ID", "Lock", "Category", "Comment", "#", "Subobject IDs"};
     const std::size_t MAX_SHOWN_SUBOBJECTS = 10;
 public:
-    int rowCount(const QModelIndex & parent = QModelIndex()) const override;
-    int columnCount(const QModelIndex & parent = QModelIndex()) const override;
-    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+    virtual int rowCount(const QModelIndex & parent = QModelIndex()) const override;
+    virtual int columnCount(const QModelIndex & parent = QModelIndex()) const override;
+    virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
     QVariant objectGet(const Segmentation::Object & obj, const QModelIndex & index, int role) const;
-    QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const override;
+    virtual QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const override;
     bool objectSet(Segmentation::Object & obj, const QModelIndex & index, const QVariant & value, int role);
-    bool setData(const QModelIndex & index, const QVariant & value, int role = Qt::EditRole) override;
-    Qt::ItemFlags flags(const QModelIndex & index) const override;
+    virtual bool setData(const QModelIndex & index, const QVariant & value, int role = Qt::EditRole) override;
+    virtual Qt::ItemFlags flags(const QModelIndex & index) const override;
     void recreate();
     void appendRowBegin();
     void popRowBegin();
@@ -79,9 +79,9 @@ class TouchedObjectModel : public SegmentationObjectModel {
     Q_OBJECT
 public:
     std::vector<std::reference_wrapper<Segmentation::Object>> objectCache;
-    int rowCount(const QModelIndex & parent = QModelIndex()) const override;
-    QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const override;
-    bool setData(const QModelIndex & index, const QVariant & value, int role = Qt::EditRole) override;
+    virtual int rowCount(const QModelIndex & parent = QModelIndex()) const override;
+    virtual QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const override;
+    virtual bool setData(const QModelIndex & index, const QVariant & value, int role = Qt::EditRole) override;
     void recreate();
 };
 
@@ -89,8 +89,8 @@ class CategoryModel : public QAbstractListModel {
     Q_OBJECT
     std::vector<QString> categoriesCache;
 public:
-    int rowCount(const QModelIndex &parent) const override;
-    QVariant data(const QModelIndex &index, int role) const override;
+    virtual int rowCount(const QModelIndex &parent) const override;
+    virtual QVariant data(const QModelIndex &index, int role) const override;
     void recreate();
 };
 

--- a/widgets/tools/skeletonview.h
+++ b/widgets/tools/skeletonview.h
@@ -50,9 +50,9 @@ class AbstractSkeletonModel : public QAbstractListModel {
 public:
     bool selectionProtection{false};
     bool selectionFromModel{false};
-    int columnCount(const QModelIndex & parent = QModelIndex()) const override;
-    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
-    Qt::ItemFlags flags(const QModelIndex & index) const override;
+    virtual int columnCount(const QModelIndex & parent = QModelIndex()) const override;
+    virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+    virtual Qt::ItemFlags flags(const QModelIndex & index) const override;
     int rowCount(const QModelIndex &) const override;
 };
 
@@ -60,7 +60,7 @@ class TreeModel : public AbstractSkeletonModel<TreeModel> {
     Q_OBJECT
     friend class AbstractSkeletonModel<TreeModel>;
     const std::vector<QString> header = {"ID", ""/*color*/, "Show", "#", "Comment", "Properties"};
-    const std::vector<Qt::ItemFlags> flagModifier = {Qt::ItemIsDropEnabled, nullptr, Qt::ItemIsUserCheckable, nullptr, Qt::ItemIsEditable, nullptr};
+    const std::vector<Qt::ItemFlags> flagModifier = {Qt::ItemIsDropEnabled, 0, Qt::ItemIsUserCheckable, 0, Qt::ItemIsEditable, 0};
 public:
     std::vector<std::reference_wrapper<class treeListElement>> cache;
     enum SynapseDisplayModes {
@@ -69,9 +69,9 @@ public:
         ShowOnly = 2
     };
     SynapseDisplayModes mode = SynapseDisplayModes::Hide;
-    QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const override;
-    bool setData(const QModelIndex & index, const QVariant & value, int role = Qt::EditRole) override;
-    bool dropMimeData(const QMimeData * data, Qt::DropAction action, int row, int column, const QModelIndex & parent) override;
+    virtual QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const override;
+    virtual bool setData(const QModelIndex & index, const QVariant & value, int role = Qt::EditRole) override;
+    virtual bool dropMimeData(const QMimeData * data, Qt::DropAction action, int row, int column, const QModelIndex & parent) override;
     void recreate();
 signals:
     void moveNodes(const QModelIndex &);
@@ -92,15 +92,15 @@ public:
         Synapse        = 1 << 5
     };
     QFlags<FilterMode> mode = FilterMode::InSelectedTree;
-    QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const override;
-    bool setData(const QModelIndex & index, const QVariant & value, int role = Qt::EditRole) override;
+    virtual QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const override;
+    virtual bool setData(const QModelIndex & index, const QVariant & value, int role = Qt::EditRole) override;
     void recreate(const bool matchAll);
 };
 
 class NodeView : public QTreeView {
     QSortFilterProxyModel & proxy;
     NodeModel & source;
-    void mousePressEvent(QMouseEvent * event) override;
+    virtual void mousePressEvent(QMouseEvent * event) override;
 public:
     NodeView(QSortFilterProxyModel & proxy, NodeModel & source) : proxy{proxy}, source{source} {}
 };

--- a/widgets/tools/skeletonview.h
+++ b/widgets/tools/skeletonview.h
@@ -53,7 +53,7 @@ public:
     virtual int columnCount(const QModelIndex & parent = QModelIndex()) const override;
     virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
     virtual Qt::ItemFlags flags(const QModelIndex & index) const override;
-    int rowCount(const QModelIndex &) const override;
+    virtual int rowCount(const QModelIndex &) const override;
 };
 
 class TreeModel : public AbstractSkeletonModel<TreeModel> {

--- a/widgets/tools/skeletonview.h
+++ b/widgets/tools/skeletonview.h
@@ -50,9 +50,9 @@ class AbstractSkeletonModel : public QAbstractListModel {
 public:
     bool selectionProtection{false};
     bool selectionFromModel{false};
-    virtual int columnCount(const QModelIndex & parent = QModelIndex()) const override;
-    virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
-    virtual Qt::ItemFlags flags(const QModelIndex & index) const override;
+    int columnCount(const QModelIndex & parent = QModelIndex()) const override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+    Qt::ItemFlags flags(const QModelIndex & index) const override;
     int rowCount(const QModelIndex &) const override;
 };
 
@@ -60,7 +60,7 @@ class TreeModel : public AbstractSkeletonModel<TreeModel> {
     Q_OBJECT
     friend class AbstractSkeletonModel<TreeModel>;
     const std::vector<QString> header = {"ID", ""/*color*/, "Show", "#", "Comment", "Properties"};
-    const std::vector<Qt::ItemFlags> flagModifier = {Qt::ItemIsDropEnabled, 0, Qt::ItemIsUserCheckable, 0, Qt::ItemIsEditable, 0};
+    const std::vector<Qt::ItemFlags> flagModifier = {Qt::ItemIsDropEnabled, nullptr, Qt::ItemIsUserCheckable, nullptr, Qt::ItemIsEditable, nullptr};
 public:
     std::vector<std::reference_wrapper<class treeListElement>> cache;
     enum SynapseDisplayModes {
@@ -69,9 +69,9 @@ public:
         ShowOnly = 2
     };
     SynapseDisplayModes mode = SynapseDisplayModes::Hide;
-    virtual QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const override;
-    virtual bool setData(const QModelIndex & index, const QVariant & value, int role = Qt::EditRole) override;
-    virtual bool dropMimeData(const QMimeData * data, Qt::DropAction action, int row, int column, const QModelIndex & parent) override;
+    QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const override;
+    bool setData(const QModelIndex & index, const QVariant & value, int role = Qt::EditRole) override;
+    bool dropMimeData(const QMimeData * data, Qt::DropAction action, int row, int column, const QModelIndex & parent) override;
     void recreate();
 signals:
     void moveNodes(const QModelIndex &);
@@ -92,15 +92,15 @@ public:
         Synapse        = 1 << 5
     };
     QFlags<FilterMode> mode = FilterMode::InSelectedTree;
-    virtual QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const override;
-    virtual bool setData(const QModelIndex & index, const QVariant & value, int role = Qt::EditRole) override;
+    QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const override;
+    bool setData(const QModelIndex & index, const QVariant & value, int role = Qt::EditRole) override;
     void recreate(const bool matchAll);
 };
 
 class NodeView : public QTreeView {
     QSortFilterProxyModel & proxy;
     NodeModel & source;
-    virtual void mousePressEvent(QMouseEvent * event) override;
+    void mousePressEvent(QMouseEvent * event) override;
 public:
     NodeView(QSortFilterProxyModel & proxy, NodeModel & source) : proxy{proxy}, source{source} {}
 };

--- a/widgets/viewports/renderer.cpp
+++ b/widgets/viewports/renderer.cpp
@@ -1720,22 +1720,22 @@ void ViewportOrtho::renderBrush(const Coordinate coord) {
             const auto x = xy || xz ? xsize : zsize;
             const auto y = xz ? zsize : ysize;
             //integer coordinates to round to voxel boundaries
-            vertices.push_back({-x    , -y    , z});
-            vertices.push_back({ x + 1, -y    , z});
-            vertices.push_back({ x + 1,  y + 1, z});
-            vertices.push_back({-x    ,  y + 1, z});
+            vertices.emplace_back(-x    , -y    , z);
+            vertices.emplace_back( x + 1, -y    , z);
+            vertices.emplace_back( x + 1,  y + 1, z);
+            vertices.emplace_back(-x    ,  y + 1, z);
         } else if(seg.brush.getShape() == brush_t::shape_t::round) {
             const int xmax = xy ? xsize : xz ? xsize : zsize;
             const int ymax = xy ? ysize : xz ? zsize : ysize;
             int y = 0;
             int x = xmax;
             auto addVerticalPixelBorder = [&vertices](float x, float y, float z) {
-                vertices.push_back({x, y    , z});
-                vertices.push_back({x, y + 1, z});
+                vertices.emplace_back(x, y    , z);
+                vertices.emplace_back(x, y + 1, z);
             };
             auto addHorizontalPixelBorder = [&vertices](float x, float y, float z) {
-                vertices.push_back({x    , y, z});
-                vertices.push_back({x + 1, y, z});
+                vertices.emplace_back(x    , y, z);
+                vertices.emplace_back(x + 1, y, z);
             };
             while (x >= y) { //first part of the ellipse (circle with anisotropic pixels), y dominant movement
                 auto val = isInsideSphere(xy ? x : xz ? x : z, xy ? y : xz ? z : y, xy ? z : xz ? y : x, bradius);

--- a/widgets/viewports/viewport3d.h
+++ b/widgets/viewports/viewport3d.h
@@ -61,14 +61,14 @@ public:
     double zoomFactor{1.0};
     QMatrix4x4 rotation;
     explicit Viewport3D(QWidget *parent, ViewportType viewportType);
-    ~Viewport3D() override;
+    virtual ~Viewport3D() override;
     virtual void showHideButtons(bool isShow) override;
     void updateVolumeTexture();
     static bool showBoundariesInUm;
 
 public slots:
-    void zoomIn() override { zoom(zoomStep()); }
-    void zoomOut() override { zoom(1.f/zoomStep()); }
+    virtual void zoomIn() override { zoom(zoomStep()); }
+    virtual void zoomOut() override { zoom(1.f/zoomStep()); }
 };
 
 #endif // VIEWPORT3D_H

--- a/widgets/viewports/viewport3d.h
+++ b/widgets/viewports/viewport3d.h
@@ -34,35 +34,35 @@ class Viewport3D : public ViewportBase {
     QAction resetAction{nullptr};
     QAction showVolumeAction{tr("Show volume"), &menuButton};
     void resetWiggle();
-    void zoom(const float zoomStep) override;
-    float zoomStep() const override;
-    void paintGL() override;
+    virtual void zoom(const float zoomStep) override;
+    virtual float zoomStep() const override;
+    virtual void paintGL() override;
     bool wiggleDirection{true};
     int wiggle{0};
     QTimer wiggletimer;
     void renderVolumeVP();
     void renderSkeletonVP(const RenderOptions & options = RenderOptions());
-    void renderViewport(const RenderOptions &options = RenderOptions()) override;
+    virtual void renderViewport(const RenderOptions &options = RenderOptions()) override;
     void renderArbitrarySlicePane(ViewportOrtho & vp, const RenderOptions & options);
-    void renderNode(const nodeListElement & node, const RenderOptions & options = RenderOptions()) override;
-    void renderViewportFrontFace() override;
+    virtual void renderNode(const nodeListElement & node, const RenderOptions & options = RenderOptions()) override;
+    virtual void renderViewportFrontFace() override;
 
-    void handleMouseMotionLeftHold(const QMouseEvent *event) override;
-    void handleMouseMotionRightHold(const QMouseEvent *event) override;
-    void handleWheelEvent(const QWheelEvent *event) override;
-    void handleKeyPress(const QKeyEvent *event) override;
-    void handleKeyRelease(const QKeyEvent *event) override;
-    void focusOutEvent(QFocusEvent *event) override;
+    virtual void handleMouseMotionLeftHold(const QMouseEvent *event) override;
+    virtual void handleMouseMotionRightHold(const QMouseEvent *event) override;
+    virtual void handleWheelEvent(const QWheelEvent *event) override;
+    virtual void handleKeyPress(const QKeyEvent *event) override;
+    virtual void handleKeyRelease(const QKeyEvent *event) override;
+    virtual void focusOutEvent(QFocusEvent *event) override;
 
 protected:
-    void renderMeshBufferIds(Mesh &buf) override;
+    virtual void renderMeshBufferIds(Mesh &buf) override;
 
 public:
     double zoomFactor{1.0};
     QMatrix4x4 rotation;
     explicit Viewport3D(QWidget *parent, ViewportType viewportType);
     ~Viewport3D() override;
-    void showHideButtons(bool isShow) override;
+    virtual void showHideButtons(bool isShow) override;
     void updateVolumeTexture();
     static bool showBoundariesInUm;
 

--- a/widgets/viewports/viewport3d.h
+++ b/widgets/viewports/viewport3d.h
@@ -34,35 +34,35 @@ class Viewport3D : public ViewportBase {
     QAction resetAction{nullptr};
     QAction showVolumeAction{tr("Show volume"), &menuButton};
     void resetWiggle();
-    virtual void zoom(const float zoomStep) override;
-    virtual float zoomStep() const override;
-    virtual void paintGL() override;
+    void zoom(const float zoomStep) override;
+    float zoomStep() const override;
+    void paintGL() override;
     bool wiggleDirection{true};
     int wiggle{0};
     QTimer wiggletimer;
     void renderVolumeVP();
     void renderSkeletonVP(const RenderOptions & options = RenderOptions());
-    virtual void renderViewport(const RenderOptions &options = RenderOptions()) override;
+    void renderViewport(const RenderOptions &options = RenderOptions()) override;
     void renderArbitrarySlicePane(ViewportOrtho & vp, const RenderOptions & options);
-    virtual void renderNode(const nodeListElement & node, const RenderOptions & options = RenderOptions()) override;
-    virtual void renderViewportFrontFace() override;
+    void renderNode(const nodeListElement & node, const RenderOptions & options = RenderOptions()) override;
+    void renderViewportFrontFace() override;
 
-    virtual void handleMouseMotionLeftHold(const QMouseEvent *event) override;
-    virtual void handleMouseMotionRightHold(const QMouseEvent *event) override;
-    virtual void handleWheelEvent(const QWheelEvent *event) override;
-    virtual void handleKeyPress(const QKeyEvent *event) override;
-    virtual void handleKeyRelease(const QKeyEvent *event) override;
-    virtual void focusOutEvent(QFocusEvent *event) override;
+    void handleMouseMotionLeftHold(const QMouseEvent *event) override;
+    void handleMouseMotionRightHold(const QMouseEvent *event) override;
+    void handleWheelEvent(const QWheelEvent *event) override;
+    void handleKeyPress(const QKeyEvent *event) override;
+    void handleKeyRelease(const QKeyEvent *event) override;
+    void focusOutEvent(QFocusEvent *event) override;
 
 protected:
-    virtual void renderMeshBufferIds(Mesh &buf) override;
+    void renderMeshBufferIds(Mesh &buf) override;
 
 public:
     double zoomFactor{1.0};
     QMatrix4x4 rotation;
     explicit Viewport3D(QWidget *parent, ViewportType viewportType);
-    ~Viewport3D();
-    virtual void showHideButtons(bool isShow) override;
+    ~Viewport3D() override;
+    void showHideButtons(bool isShow) override;
     void updateVolumeTexture();
     static bool showBoundariesInUm;
 

--- a/widgets/viewports/viewportarb.h
+++ b/widgets/viewports/viewportarb.h
@@ -31,13 +31,13 @@ class ViewportArb : public ViewportOrtho {
     void updateOverlayTexture();
 
 protected:
-    virtual void paintGL() override;
-    virtual void hideVP() override;
+    void paintGL() override;
+    void hideVP() override;
 public:
     floatCoordinate leftUpperPxInAbsPx_float;
     ViewportArb(QWidget *parent, ViewportType viewportType);
 
-    virtual float displayedEdgeLenghtXForZoomFactor(const float zoomFactor) const override;
+    float displayedEdgeLenghtXForZoomFactor(const float zoomFactor) const override;
 };
 
 #endif // VIEWPORTARB_H

--- a/widgets/viewports/viewportarb.h
+++ b/widgets/viewports/viewportarb.h
@@ -31,13 +31,13 @@ class ViewportArb : public ViewportOrtho {
     void updateOverlayTexture();
 
 protected:
-    void paintGL() override;
-    void hideVP() override;
+    virtual void paintGL() override;
+    virtual void hideVP() override;
 public:
     floatCoordinate leftUpperPxInAbsPx_float;
     ViewportArb(QWidget *parent, ViewportType viewportType);
 
-    float displayedEdgeLenghtXForZoomFactor(const float zoomFactor) const override;
+    virtual float displayedEdgeLenghtXForZoomFactor(const float zoomFactor) const override;
 };
 
 #endif // VIEWPORTARB_H

--- a/widgets/viewports/viewportbase.h
+++ b/widgets/viewports/viewportbase.h
@@ -97,7 +97,7 @@ Q_DECLARE_METATYPE(SnapshotOptions)
 class ViewportBase;
 class ResizeButton : public QPushButton {
     Q_OBJECT
-    virtual void mouseMoveEvent(QMouseEvent * event) override;
+    void mouseMoveEvent(QMouseEvent * event) override;
 public:
     explicit ResizeButton(QWidget *parent) : QPushButton(parent) {}
 signals:
@@ -108,10 +108,10 @@ signals:
 class QViewportFloatWidget : public QDialog {
     ViewportBase *vp;
 protected:
-    virtual void closeEvent(QCloseEvent *event) override;
-    virtual void moveEvent(QMoveEvent *event) override;
-    virtual void resizeEvent(QResizeEvent *event) override;
-    virtual void showEvent(QShowEvent *event) override;
+    void closeEvent(QCloseEvent *event) override;
+    void moveEvent(QMoveEvent *event) override;
+    void resizeEvent(QResizeEvent *event) override;
+    void showEvent(QShowEvent *event) override;
 public:
     bool fullscreen{false};
     boost::optional<QPoint> nonMaximizedPos;
@@ -154,7 +154,7 @@ private:
 
     QSet<nodeListElement *> nodeSelection(int x, int y);
     // rendering
-    virtual void resizeGL(int width, int height) override;
+    void resizeGL(int width, int height) override;
     bool sphereInFrustum(floatCoordinate pos, float radius);
 
     void renderMeshBuffer(Mesh & buf);
@@ -171,7 +171,7 @@ protected:
     virtual float zoomStep() const = 0;
     void applyZoom(const QWheelEvent *event, float direction = 1.0f);
     // rendering
-    virtual void initializeGL() override;
+    void initializeGL() override;
     virtual void hideVP();
     void setFrontFacePerspective();
     void renderScaleBar();
@@ -189,19 +189,19 @@ protected:
     boost::optional<nodeListElement &> pickNode(int x, int y, int width);
     void handleLinkToggle(const QMouseEvent & event);
 
-    virtual void moveEvent(QMoveEvent *event) override;
-    virtual void resizeEvent(QResizeEvent *event) override;
+    void moveEvent(QMoveEvent *event) override;
+    void resizeEvent(QResizeEvent *event) override;
 
     // event-handling
-    virtual void enterEvent(QEvent * event) override;
-    virtual void leaveEvent(QEvent * event) override;
-    virtual void mouseMoveEvent(QMouseEvent *event) override;
-    virtual void mousePressEvent(QMouseEvent *event) override;
-    virtual void mouseReleaseEvent(QMouseEvent *event) override;
-    virtual void tabletEvent(QTabletEvent *event) override;
-    virtual void keyPressEvent(QKeyEvent *event) override;
-    virtual void keyReleaseEvent(QKeyEvent *event) override;
-    virtual void wheelEvent(QWheelEvent *event) override { handleWheelEvent(event); }
+    void enterEvent(QEvent * event) override;
+    void leaveEvent(QEvent * event) override;
+    void mouseMoveEvent(QMouseEvent *event) override;
+    void mousePressEvent(QMouseEvent *event) override;
+    void mouseReleaseEvent(QMouseEvent *event) override;
+    void tabletEvent(QTabletEvent *event) override;
+    void keyPressEvent(QKeyEvent *event) override;
+    void keyReleaseEvent(QKeyEvent *event) override;
+    void wheelEvent(QWheelEvent *event) override { handleWheelEvent(event); }
 
     float zoomSpeed{0.5f};
     QPoint mouseDown;
@@ -259,7 +259,7 @@ public:
     static bool oglDebug;
 
     explicit ViewportBase(QWidget *parent, ViewportType viewportType);
-    virtual ~ViewportBase();
+    ~ViewportBase() override;
 
     //This is a bit confusing..the screen coordinate system has always
     //x on the horizontal and y on the verical axis, but the displayed

--- a/widgets/viewports/viewportbase.h
+++ b/widgets/viewports/viewportbase.h
@@ -97,7 +97,7 @@ Q_DECLARE_METATYPE(SnapshotOptions)
 class ViewportBase;
 class ResizeButton : public QPushButton {
     Q_OBJECT
-    void mouseMoveEvent(QMouseEvent * event) override;
+    virtual void mouseMoveEvent(QMouseEvent * event) override;
 public:
     explicit ResizeButton(QWidget *parent) : QPushButton(parent) {}
 signals:
@@ -108,10 +108,10 @@ signals:
 class QViewportFloatWidget : public QDialog {
     ViewportBase *vp;
 protected:
-    void closeEvent(QCloseEvent *event) override;
-    void moveEvent(QMoveEvent *event) override;
-    void resizeEvent(QResizeEvent *event) override;
-    void showEvent(QShowEvent *event) override;
+    virtual void closeEvent(QCloseEvent *event) override;
+    virtual void moveEvent(QMoveEvent *event) override;
+    virtual void resizeEvent(QResizeEvent *event) override;
+    virtual void showEvent(QShowEvent *event) override;
 public:
     bool fullscreen{false};
     boost::optional<QPoint> nonMaximizedPos;
@@ -154,7 +154,7 @@ private:
 
     QSet<nodeListElement *> nodeSelection(int x, int y);
     // rendering
-    void resizeGL(int width, int height) override;
+    virtual void resizeGL(int width, int height) override;
     bool sphereInFrustum(floatCoordinate pos, float radius);
 
     void renderMeshBuffer(Mesh & buf);
@@ -171,7 +171,7 @@ protected:
     virtual float zoomStep() const = 0;
     void applyZoom(const QWheelEvent *event, float direction = 1.0f);
     // rendering
-    void initializeGL() override;
+    virtual void initializeGL() override;
     virtual void hideVP();
     void setFrontFacePerspective();
     void renderScaleBar();
@@ -189,19 +189,19 @@ protected:
     boost::optional<nodeListElement &> pickNode(int x, int y, int width);
     void handleLinkToggle(const QMouseEvent & event);
 
-    void moveEvent(QMoveEvent *event) override;
-    void resizeEvent(QResizeEvent *event) override;
+    virtual void moveEvent(QMoveEvent *event) override;
+    virtual void resizeEvent(QResizeEvent *event) override;
 
     // event-handling
-    void enterEvent(QEvent * event) override;
-    void leaveEvent(QEvent * event) override;
-    void mouseMoveEvent(QMouseEvent *event) override;
-    void mousePressEvent(QMouseEvent *event) override;
-    void mouseReleaseEvent(QMouseEvent *event) override;
-    void tabletEvent(QTabletEvent *event) override;
-    void keyPressEvent(QKeyEvent *event) override;
-    void keyReleaseEvent(QKeyEvent *event) override;
-    void wheelEvent(QWheelEvent *event) override { handleWheelEvent(event); }
+    virtual void enterEvent(QEvent * event) override;
+    virtual void leaveEvent(QEvent * event) override;
+    virtual void mouseMoveEvent(QMouseEvent *event) override;
+    virtual void mousePressEvent(QMouseEvent *event) override;
+    virtual void mouseReleaseEvent(QMouseEvent *event) override;
+    virtual void tabletEvent(QTabletEvent *event) override;
+    virtual void keyPressEvent(QKeyEvent *event) override;
+    virtual void keyReleaseEvent(QKeyEvent *event) override;
+    virtual void wheelEvent(QWheelEvent *event) override { handleWheelEvent(event); }
 
     float zoomSpeed{0.5f};
     QPoint mouseDown;
@@ -259,7 +259,7 @@ public:
     static bool oglDebug;
 
     explicit ViewportBase(QWidget *parent, ViewportType viewportType);
-    ~ViewportBase() override;
+    virtual ~ViewportBase() override;
 
     //This is a bit confusing..the screen coordinate system has always
     //x on the horizontal and y on the verical axis, but the displayed

--- a/widgets/viewports/viewportevents.cpp
+++ b/widgets/viewports/viewportevents.cpp
@@ -52,7 +52,7 @@ void merging(const QMouseEvent *event, ViewportOrtho & vp) {
     auto & seg = Segmentation::singleton();
     const auto brushCenter = getCoordinateFromOrthogonalClick(event->pos(), vp);
     const auto subobjectIds = readVoxels(brushCenter, seg.brush.value());
-    for (const auto& subobjectPair : subobjectIds) {
+    for (const auto & subobjectPair : subobjectIds) {
         if (seg.selectedObjectsCount() == 1) {
             const auto soid = subobjectPair.first;
             const auto pos = subobjectPair.second;

--- a/widgets/viewports/viewportevents.cpp
+++ b/widgets/viewports/viewportevents.cpp
@@ -52,7 +52,7 @@ void merging(const QMouseEvent *event, ViewportOrtho & vp) {
     auto & seg = Segmentation::singleton();
     const auto brushCenter = getCoordinateFromOrthogonalClick(event->pos(), vp);
     const auto subobjectIds = readVoxels(brushCenter, seg.brush.value());
-    for (const auto subobjectPair : subobjectIds) {
+    for (const auto& subobjectPair : subobjectIds) {
         if (seg.selectedObjectsCount() == 1) {
             const auto soid = subobjectPair.first;
             const auto pos = subobjectPair.second;

--- a/widgets/viewports/viewportortho.h
+++ b/widgets/viewports/viewportortho.h
@@ -38,43 +38,43 @@ class ViewportOrtho : public ViewportBase {
     QAction zoomResetAction{tr("Reset zoom"), &menuButton};
 
     floatCoordinate handleMovement(const QPoint & pos);
-    virtual void zoom(const float zoomStep) override;
-    virtual float zoomStep() const override { return 0.75; }
+    void zoom(const float zoomStep) override;
+    float zoomStep() const override { return 0.75; }
 
     void renderViewportFast();
-    virtual void renderViewport(const RenderOptions &options = RenderOptions()) override;
-    virtual void renderSegment(const segmentListElement & segment, const QColor &color, const RenderOptions & options = RenderOptions()) override;
+    void renderViewport(const RenderOptions &options = RenderOptions()) override;
+    void renderSegment(const segmentListElement & segment, const QColor &color, const RenderOptions & options = RenderOptions()) override;
     void renderSegPlaneIntersection(const segmentListElement & segment);
-    virtual void renderNode(const nodeListElement & node, const RenderOptions & options = RenderOptions()) override;
+    void renderNode(const nodeListElement & node, const RenderOptions & options = RenderOptions()) override;
     void renderBrush(const Coordinate coord);
-    virtual void renderViewportFrontFace() override;
+    void renderViewportFrontFace() override;
 
     floatCoordinate arbNodeDragCache = {};
     class nodeListElement *draggedNode = nullptr;
 
-    virtual void mousePressEvent(QMouseEvent *event) override;
-    virtual void mouseMoveEvent(QMouseEvent *event) override;
+    void mousePressEvent(QMouseEvent *event) override;
+    void mouseMoveEvent(QMouseEvent *event) override;
 
-    virtual void handleKeyPress(const QKeyEvent *event) override;
-    virtual void handleMouseHover(const QMouseEvent *event) override;
-    virtual void handleMouseReleaseLeft(const QMouseEvent *event) override;
-    virtual void handleMouseMotionLeftHold(const QMouseEvent *event) override;
-    virtual void handleMouseButtonRight(const QMouseEvent *event) override;
-    virtual void handleMouseMotionRightHold(const QMouseEvent *event) override;
-    virtual void handleMouseReleaseRight(const QMouseEvent *event) override;
-    virtual void handleMouseButtonMiddle(const QMouseEvent *event) override;
-    virtual void handleMouseMotionMiddleHold(const QMouseEvent *event) override;
-    virtual void handleMouseReleaseMiddle(const QMouseEvent *event) override;
-    virtual void handleWheelEvent(const QWheelEvent *event) override;
+    void handleKeyPress(const QKeyEvent *event) override;
+    void handleMouseHover(const QMouseEvent *event) override;
+    void handleMouseReleaseLeft(const QMouseEvent *event) override;
+    void handleMouseMotionLeftHold(const QMouseEvent *event) override;
+    void handleMouseButtonRight(const QMouseEvent *event) override;
+    void handleMouseMotionRightHold(const QMouseEvent *event) override;
+    void handleMouseReleaseRight(const QMouseEvent *event) override;
+    void handleMouseButtonMiddle(const QMouseEvent *event) override;
+    void handleMouseMotionMiddleHold(const QMouseEvent *event) override;
+    void handleMouseReleaseMiddle(const QMouseEvent *event) override;
+    void handleWheelEvent(const QWheelEvent *event) override;
 
 protected:
-    virtual void initializeGL() override;
-    virtual void paintGL() override;
+    void initializeGL() override;
+    void paintGL() override;
 
-    virtual void renderMeshBufferIds(Mesh &buf) override;
+    void renderMeshBufferIds(Mesh &buf) override;
 public:
     explicit ViewportOrtho(QWidget *parent, ViewportType viewportType);
-    ~ViewportOrtho();
+    ~ViewportOrtho() override;
     void resetTexture(const std::size_t layerCount);
     void setTextureFilter(const QOpenGLTexture::Filter textureFilter);
     static bool showNodeComments;

--- a/widgets/viewports/viewportortho.h
+++ b/widgets/viewports/viewportortho.h
@@ -74,7 +74,7 @@ protected:
     virtual void renderMeshBufferIds(Mesh &buf) override;
 public:
     explicit ViewportOrtho(QWidget *parent, ViewportType viewportType);
-    ~ViewportOrtho() override;
+    virtual ~ViewportOrtho() override;
     void resetTexture(const std::size_t layerCount);
     void setTextureFilter(const QOpenGLTexture::Filter textureFilter);
     static bool showNodeComments;
@@ -96,8 +96,8 @@ public:
     virtual float displayedEdgeLenghtXForZoomFactor(const float zoomFactor) const;
 
 public slots:
-    void zoomIn() override { zoom(zoomStep()); }
-    void zoomOut() override { zoom(1.f/zoomStep()); }
+    virtual void zoomIn() override { zoom(zoomStep()); }
+    virtual void zoomOut() override { zoom(1.f/zoomStep()); }
 };
 
 #endif // VIEWPORTORTHO_H

--- a/widgets/viewports/viewportortho.h
+++ b/widgets/viewports/viewportortho.h
@@ -38,40 +38,40 @@ class ViewportOrtho : public ViewportBase {
     QAction zoomResetAction{tr("Reset zoom"), &menuButton};
 
     floatCoordinate handleMovement(const QPoint & pos);
-    void zoom(const float zoomStep) override;
-    float zoomStep() const override { return 0.75; }
+    virtual void zoom(const float zoomStep) override;
+    virtual float zoomStep() const override { return 0.75; }
 
-    void renderViewportFast();
-    void renderViewport(const RenderOptions &options = RenderOptions()) override;
-    void renderSegment(const segmentListElement & segment, const QColor &color, const RenderOptions & options = RenderOptions()) override;
+    virtual void renderViewportFast();
+    virtual void renderViewport(const RenderOptions &options = RenderOptions()) override;
+    virtual void renderSegment(const segmentListElement & segment, const QColor &color, const RenderOptions & options = RenderOptions()) override;
     void renderSegPlaneIntersection(const segmentListElement & segment);
-    void renderNode(const nodeListElement & node, const RenderOptions & options = RenderOptions()) override;
+    virtual void renderNode(const nodeListElement & node, const RenderOptions & options = RenderOptions()) override;
     void renderBrush(const Coordinate coord);
-    void renderViewportFrontFace() override;
+    virtual void renderViewportFrontFace() override;
 
     floatCoordinate arbNodeDragCache = {};
     class nodeListElement *draggedNode = nullptr;
 
-    void mousePressEvent(QMouseEvent *event) override;
-    void mouseMoveEvent(QMouseEvent *event) override;
+    virtual void mousePressEvent(QMouseEvent *event) override;
+    virtual void mouseMoveEvent(QMouseEvent *event) override;
 
-    void handleKeyPress(const QKeyEvent *event) override;
-    void handleMouseHover(const QMouseEvent *event) override;
-    void handleMouseReleaseLeft(const QMouseEvent *event) override;
-    void handleMouseMotionLeftHold(const QMouseEvent *event) override;
-    void handleMouseButtonRight(const QMouseEvent *event) override;
-    void handleMouseMotionRightHold(const QMouseEvent *event) override;
-    void handleMouseReleaseRight(const QMouseEvent *event) override;
-    void handleMouseButtonMiddle(const QMouseEvent *event) override;
-    void handleMouseMotionMiddleHold(const QMouseEvent *event) override;
-    void handleMouseReleaseMiddle(const QMouseEvent *event) override;
-    void handleWheelEvent(const QWheelEvent *event) override;
+    virtual void handleKeyPress(const QKeyEvent *event) override;
+    virtual void handleMouseHover(const QMouseEvent *event) override;
+    virtual void handleMouseReleaseLeft(const QMouseEvent *event) override;
+    virtual void handleMouseMotionLeftHold(const QMouseEvent *event) override;
+    virtual void handleMouseButtonRight(const QMouseEvent *event) override;
+    virtual void handleMouseMotionRightHold(const QMouseEvent *event) override;
+    virtual void handleMouseReleaseRight(const QMouseEvent *event) override;
+    virtual void handleMouseButtonMiddle(const QMouseEvent *event) override;
+    virtual void handleMouseMotionMiddleHold(const QMouseEvent *event) override;
+    virtual void handleMouseReleaseMiddle(const QMouseEvent *event) override;
+    virtual void handleWheelEvent(const QWheelEvent *event) override;
 
 protected:
-    void initializeGL() override;
-    void paintGL() override;
+    virtual void initializeGL() override;
+    virtual void paintGL() override;
 
-    void renderMeshBufferIds(Mesh &buf) override;
+    virtual void renderMeshBufferIds(Mesh &buf) override;
 public:
     explicit ViewportOrtho(QWidget *parent, ViewportType viewportType);
     ~ViewportOrtho() override;


### PR DESCRIPTION
Qt Creator 4.6 includes the clang-tidy [1] plugin.

The changes were made with the following settings enabled:
- clang-analyzer-*
- clang-diagnostic-*
- modernize-*
- performance-*
- readability-*

Not all proposed changes where implemented, since some would break the functionality.

[1] - http://clang.llvm.org/extra/clang-tidy/